### PR TITLE
prevent error when file not found

### DIFF
--- a/src/FilemanagerField.php
+++ b/src/FilemanagerField.php
@@ -36,6 +36,10 @@ class FilemanagerField extends Field
 
             $data = $service->getFileInfoAsArray($this->value);
 
+            if (empty($data)) {
+                return [];
+            }
+
             return $this->fixNameLabel($data);
         }
 


### PR DESCRIPTION
Method returns empty array when file does not exist
https://github.com/InfinetyES/Nova-Filemanager/blob/e0c8bb7745422bcf837769ce92ede45c4e6226a4/src/Http/Services/FileManagerService.php#L168-L172
and it throws error **"Undefined index: name"** in this method
https://github.com/InfinetyES/Nova-Filemanager/blob/e0c8bb7745422bcf837769ce92ede45c4e6226a4/src/FilemanagerField.php#L39