### PR TITLE
Fix file upload error after navigating to root directory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,5 +49,6 @@
         "sort-packages": true
     },
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "version": "2.2.1"
 }

--- a/src/Http/Controllers/FilemanagerToolController.php
+++ b/src/Http/Controllers/FilemanagerToolController.php
@@ -61,7 +61,7 @@ class FilemanagerToolController extends Controller
      */
     public function upload(Request $request)
     {
-        return $this->service->uploadFile($request->file, $request->current, $request->visibility);
+        return $this->service->uploadFile($request->file, $request->current ?? '', $request->visibility);
     }
 
     /**


### PR DESCRIPTION
See #59 

This fixes an issue where file uploads fail after navigating into a folder and back out to the top-level directory.