### PR TITLE
Fix issue #75

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     ],
     "require": {
         "php": ">=7.1.0",
+        "laravel/helpers": "^1.1",
         "laravel/nova": "~2.0"
     },
     "require-dev": {


### PR DESCRIPTION
This package use laravel helper function like starts_with(), but in version 6, laravel extracted helper functions into a separate package.
To fix the error, it needs to install https://github.com/laravel/helpers

This PR will resolve errors like issue #75 when laravel upgraded to version 6.