### PR TITLE
Fix for empty parent path

### DIFF
--- a/src/Http/Services/GetFiles.php
+++ b/src/Http/Services/GetFiles.php
@@ -436,7 +436,7 @@ trait GetFiles
         if ($paths) {
             $folderPath = $paths->implode('/');
 
-            if ($folderPath == $folder) {
+            if ($folderPath == $folder || strlen($folderPath) === 0) {
                 $folderPath = '/';
             }
 


### PR DESCRIPTION
I mounted my instance of Filemanager to the root of an S3 bucket. When navigating into a folder, an exception was thrown because the parent directory was attempting to resolve a url to S3 with an empty URI parameter. This change seems to fix that problem.

Example exception:

> \Storage::disk('s3')->url('');
> InvalidArgumentException with message 'Found 1 error while validating the input provided for the GetObject operation:
> [Key] expected string length to be >= 1, but found string length of 0'
