### PR TITLE
Nova 3.0 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": ">=7.1.0",
-        "laravel/nova": "~2.0"
+        "laravel/nova": "~2.0|~3.0"
     },
     "require-dev": {
         "orchestra/testbench": "^3.6",


### PR DESCRIPTION
Nova 3.0 Support for Laravel 7.
I've tested most of the things. Everything worked fine for me.