### PR TITLE
Fix error when using remote filesystem

### DIFF
--- a/src/Http/Services/GetFiles.php
+++ b/src/Http/Services/GetFiles.php
@@ -72,7 +72,7 @@ trait GetFiles
                 'size'       => ($file['size'] != 0) ? $file['size'] : 0,
                 'size_human' => ($file['size'] != 0) ? $this->formatBytes($file['size'], 0) : 0,
                 'thumb'      => $this->getThumbFile($file),
-                'asset'      => $this->cleanSlashes($this->storage->url($file['basename'])),
+                //'asset'      => $this->cleanSlashes($this->storage->url($file['basename'])),
                 'can'        => true,
                 'loading'    => false,
             ];
@@ -450,7 +450,7 @@ trait GetFiles
                 'size'              => 0,
                 'size_human'        => 0,
                 'thumb'             => '',
-                'asset'             => $this->cleanSlashes($this->storage->url($folderPath)),
+                //'asset'             => $this->cleanSlashes($this->storage->url($folderPath)),
                 'can'               => true,
                 'loading'           => false,
                 'last_modification' => false,


### PR DESCRIPTION
When i use Spatie\Dropbox i get error:
[message]
path/not_file/.. {"userId":1,"exception":"[object] (Spatie\\Dropbox\\Exceptions\\BadRequest(code: 0): path/not_file/.. at /Users/username/Code/project/vendor/spatie/dropbox-api/src/Client.php:657)

We do not use this data and can hide it.
This suggestion will solve this problem