### PR TITLE
adding the possibility to change disk config at runtime through middlewares and support for s3 private buckets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ composer.phar
 composer.lock
 phpunit.xml
 mix-manifest.json
+/.idea

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/filemanager.iml" filepath="$PROJECT_DIR$/.idea/filemanager.iml" />
+    </modules>
+  </component>
+</project>

--- a/src/Http/Controllers/FilemanagerToolController.php
+++ b/src/Http/Controllers/FilemanagerToolController.php
@@ -9,17 +9,12 @@ use Laravel\Nova\Http\Requests\NovaRequest;
 
 class FilemanagerToolController extends Controller
 {
-    /**
-     * @var mixed
-     */
-    protected $service;
 
     /**
-     * @param FileManagerService $filemanagerService
+     * @return FileManagerService
      */
-    public function __construct(FileManagerService $filemanagerService)
-    {
-        $this->service = $filemanagerService;
+    protected function service(){
+        return $this->service =  new FileManagerService();
     }
 
     /**
@@ -27,7 +22,7 @@ class FilemanagerToolController extends Controller
      */
     public function getData(Request $request)
     {
-        return $this->service->ajaxGetFilesAndFolders($request);
+        return $this->service()->ajaxGetFilesAndFolders($request);
     }
 
     /**
@@ -35,7 +30,7 @@ class FilemanagerToolController extends Controller
      */
     public function getDataField($resource, $attribute, NovaRequest $request)
     {
-        return $this->service->ajaxGetFilesAndFolders($request);
+        return $this->service()->ajaxGetFilesAndFolders($request);
     }
 
     /**
@@ -43,7 +38,7 @@ class FilemanagerToolController extends Controller
      */
     public function createFolder(Request $request)
     {
-        return $this->service->createFolderOnPath($request->folder, $request->current);
+        return $this->service()->createFolderOnPath($request->folder, $request->current);
     }
 
     /**
@@ -51,7 +46,7 @@ class FilemanagerToolController extends Controller
      */
     public function deleteFolder(Request $request)
     {
-        return $this->service->deleteDirectory($request->current);
+        return $this->service()->deleteDirectory($request->current);
     }
 
     /**
@@ -61,7 +56,7 @@ class FilemanagerToolController extends Controller
     {
         $uploadingFolder = $request->folder ?? false;
 
-        return $this->service->uploadFile(
+        return $this->service()->uploadFile(
             $request->file,
             $request->current ?? '',
             $request->visibility,
@@ -75,7 +70,7 @@ class FilemanagerToolController extends Controller
      */
     public function move(Request $request)
     {
-        return $this->service->moveFile($request->old, $request->path);
+        return $this->service()->moveFile($request->old, $request->path);
     }
 
     /**
@@ -83,7 +78,7 @@ class FilemanagerToolController extends Controller
      */
     public function getInfo(Request $request)
     {
-        return $this->service->getFileInfo($request->file);
+        return $this->service()->getFileInfo($request->file);
     }
 
     /**
@@ -91,7 +86,7 @@ class FilemanagerToolController extends Controller
      */
     public function removeFile(Request $request)
     {
-        return $this->service->removeFile($request->file, $request->type);
+        return $this->service()->removeFile($request->file, $request->type);
     }
 
     /**
@@ -99,7 +94,7 @@ class FilemanagerToolController extends Controller
      */
     public function renameFile(Request $request)
     {
-        return $this->service->renameFile($request->file, $request->name);
+        return $this->service()->renameFile($request->file, $request->name);
     }
 
     /**
@@ -107,7 +102,7 @@ class FilemanagerToolController extends Controller
      */
     public function downloadFile(Request $request)
     {
-        return $this->service->downloadFile($request->file);
+        return $this->service()->downloadFile($request->file);
     }
 
     /**
@@ -115,7 +110,7 @@ class FilemanagerToolController extends Controller
      */
     public function rename(Request $request)
     {
-        return $this->service->renameFile($request->path, $request->name);
+        return $this->service()->renameFile($request->path, $request->name);
     }
 
     /**
@@ -123,7 +118,7 @@ class FilemanagerToolController extends Controller
      */
     public function folderUploadedEvent(Request $request)
     {
-        return $this->service->folderUploadedEvent($request->path);
+        return $this->service()->folderUploadedEvent($request->path);
     }
 
     /**

--- a/src/Http/Services/GetFiles.php
+++ b/src/Http/Services/GetFiles.php
@@ -4,12 +4,12 @@ namespace Infinety\Filemanager\Http\Services;
 
 use Carbon\Carbon;
 use GuzzleHttp\Client;
-use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use Infinety\Filemanager\Traits\StorageHelpers;
 
 trait GetFiles
 {
-    use FileFunctions;
+    use FileFunctions, StorageHelpers;
 
     /**
      * Cloud disks.
@@ -72,7 +72,7 @@ trait GetFiles
                 'size'       => ($file['size'] != 0) ? $file['size'] : 0,
                 'size_human' => ($file['size'] != 0) ? $this->formatBytes($file['size'], 0) : 0,
                 'thumb'      => $this->getThumbFile($file),
-                'asset'      => $this->cleanSlashes($this->storage->url($file['basename'])),
+                'asset'      => $this->cleanSlashes($this->url($this->storage,$file['basename'])),
                 'can'        => true,
                 'loading'    => false,
             ];
@@ -320,7 +320,7 @@ trait GetFiles
 
         if (Str::contains($mime, 'image') || $extension == 'svg') {
             if (method_exists($this->storage, 'put')) {
-                return $this->storage->url($file['path']);
+                return $this->url($this->storage, $file['path']);
             }
 
             return $folder.'/'.$file['basename'];
@@ -359,7 +359,7 @@ trait GetFiles
         try {
             $client = new Client();
 
-            $response = $client->get($this->storage->url($file['path']), ['stream' => true]);
+            $response = $client->get($this->url($this->storage, $file['path']), ['stream' => true]);
             $image = imagecreatefromstring($response->getBody()->getContents());
             $dims = [imagesx($image), imagesy($image)];
             imagedestroy($image);
@@ -450,7 +450,7 @@ trait GetFiles
                 'size'              => 0,
                 'size_human'        => 0,
                 'thumb'             => '',
-                'asset'             => $this->cleanSlashes($this->storage->url($folderPath)),
+                'asset'             => $this->cleanSlashes($this->url($this->storage, $folderPath)),
                 'can'               => true,
                 'loading'           => false,
                 'last_modification' => false,

--- a/src/Http/Services/NormalizeFile.php
+++ b/src/Http/Services/NormalizeFile.php
@@ -6,13 +6,14 @@ use Carbon\Carbon;
 use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Infinety\Filemanager\Traits\StorageHelpers;
 use RarArchive;
 use SplFileInfo;
 use ZipArchive;
 
 class NormalizeFile
 {
-    use FileFunctions;
+    use FileFunctions, StorageHelpers;
 
     /**
      * @var mixed
@@ -50,7 +51,7 @@ class NormalizeFile
             'mime' => $this->getCorrectMimeFileType(),
             'path' => $this->storagePath,
             'size' => $this->getFileSize(),
-            'url'  => $this->cleanSlashes($this->storage->url($this->storagePath)),
+            'url'  => $this->cleanSlashes($this->url($this->storage,$this->storagePath)),
             'date' => $this->modificationDate(),
             'ext'  => $this->file->getExtension(),
         ]);
@@ -77,7 +78,7 @@ class NormalizeFile
         // Video
         if (Str::contains($mime, 'audio')) {
             $data->put('type', 'audio');
-            $src = str_replace(env('APP_URL'), '', $this->storage->url($this->storagePath));
+            $src = str_replace(env('APP_URL'), '', $this->url($this->storage,$this->storagePath));
             $data->put('src', $src);
         }
 
@@ -145,7 +146,7 @@ class NormalizeFile
     private function getImage($mime, $extension = false)
     {
         if (Str::contains($mime, 'image') || $extension == 'svg') {
-            return $this->storage->url($this->storagePath);
+            return $this->url($this->storage,$this->storagePath);
         }
 
         $fileType = new FileTypesImages();

--- a/src/Traits/StorageHelpers.php
+++ b/src/Traits/StorageHelpers.php
@@ -1,0 +1,18 @@
+<?php
+
+
+namespace Infinety\Filemanager\Traits;
+
+use Illuminate\Filesystem\FilesystemAdapter;
+use League\Flysystem\AwsS3v3\AwsS3Adapter;
+
+trait StorageHelpers
+{
+    public function url(FilesystemAdapter $fs, $path, $expiration = "+ 1 hour", $options=[]){
+        $adapter = $fs->getDriver()->getAdapter();
+        if ($adapter instanceof AwsS3Adapter){
+            return $fs->getAwsTemporaryUrl($adapter, $path, $expiration, $options);
+        }
+        return $fs->url($path);
+    }
+}


### PR DESCRIPTION
couple of changes that allow changing root path  or any disk config at runtime through middlewares based on demand (user id for instance).
adding signed temporaryUrl instead to url for s3 adapter to tackle the problem of private buckets.